### PR TITLE
update method artikel add val kosong parameter

### DIFF
--- a/donjo-app/controllers/First.php
+++ b/donjo-app/controllers/First.php
@@ -183,8 +183,9 @@ class First extends Web_Controller {
 		$this->set_template('layouts/mandiri.php');
 		$this->load->view($this->template, $data);
 	}
-
-	public function artikel($thn, $bln, $hri, $slug = NULL, $p=1)
+	
+	// tambah parameter default karena pada php versi 7.1 keatas jika tidak ada value pada parameter ketika akses page artikel dengan menggunakan id terjadi error 500 ini terjadi saat redirect setelah mengirim komentar
+	public function artikel($thn, $bln = '', $hri = '', $slug = NULL, $p=1)
 	{
 		$data = $this->includes;
 


### PR DESCRIPTION
pada php versi 7.1 keatas halaman terjadi error 500 apabila mengakses halaman /first/artikel/$id   ,, bugs ini saya temukan ketika redirect setelah mengirim komentar maka otomatis akan me link ke halaman artikel kembali tapi url menggunakan id tidak menggunakan slug. 
yg di fix hanya menambah parameter kosong di method artikel . di controller first.php

Solusi untuk {perbaikan|fitur baru} terkait issue {#1, #2, #3, dst.}

